### PR TITLE
Post-#34 cleanups: CTA helper, navItemsField factory, prop rename, comment strip

### DIFF
--- a/src/app/(frontend)/_components/render-blocks.tsx
+++ b/src/app/(frontend)/_components/render-blocks.tsx
@@ -9,7 +9,7 @@ import { FeatureList } from "~/features/marketing/components/feature-list";
 import { HomeHero } from "~/features/marketing/components/home-hero";
 import { Story } from "~/features/marketing/components/story";
 import { ProjectShowcase } from "~/features/portfolio/components/project-showcase";
-import { type ResolvedCta, resolveLink } from "~/lib/page-href";
+import { type ResolvedCta, resolveCta } from "~/lib/page-href";
 import { resolveMedia } from "~/lib/resolve-media";
 import type { HeroBlock, Page, StoryBlock } from "~/payload-types";
 
@@ -18,10 +18,8 @@ type Lockup = HeroBlock["lockup"];
 
 function resolveCtas(ctas: Lockup["ctas"]): Array<ResolvedCta> {
   return (ctas ?? []).flatMap((cta) => {
-    const link = resolveLink(cta);
-    return cta.label && link
-      ? [{ download: link.download, href: link.href, label: cta.label }]
-      : [];
+    const resolved = resolveCta(cta);
+    return resolved ? [resolved] : [];
   });
 }
 

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -3,15 +3,11 @@ import type { Metadata } from "next";
 import { Geist, Space_Grotesk } from "next/font/google";
 import type { ReactNode } from "react";
 import { SiteFooter, type SocialLink } from "~/components/site-footer";
-import {
-  type NavCta,
-  type NavLink,
-  SiteHeader,
-} from "~/components/site-header";
+import { type NavLink, SiteHeader } from "~/components/site-header";
 import { ThemeProvider } from "~/components/theme-provider";
 import { siteConfig } from "~/config/site";
 import { cn } from "~/lib/cn";
-import { pageRelationshipHref, resolveLink } from "~/lib/page-href";
+import { pageRelationshipHref, resolveCta } from "~/lib/page-href";
 import { getGlobal } from "~/lib/payload";
 import type { Footer, Navigation } from "~/payload-types";
 import "../globals.css";
@@ -63,14 +59,6 @@ function toNavLinks(
   });
 }
 
-function toNavCta(cta: Navigation["cta"]): NavCta | null {
-  const link = resolveLink(cta);
-  if (!(cta?.label && link)) {
-    return null;
-  }
-  return { download: link.download, href: link.href, label: cta.label };
-}
-
 function toSocialLinks(links: Footer["socialLinks"]): Array<SocialLink> {
   return (links ?? []).map((link) => ({
     platform: link.platform,
@@ -102,7 +90,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
           enableSystem
         >
           <SiteHeader
-            cta={toNavCta(navigation.cta)}
+            cta={resolveCta(navigation.cta)}
             items={toNavLinks(navigation.items)}
           />
           <main className="flex flex-1 flex-col">{children}</main>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -20,13 +20,13 @@ function isActive({ pathname, href }: { pathname: string; href: string }) {
   return href === "/" ? pathname === "/" : pathname.startsWith(href);
 }
 
-type NavLinkProps = {
+type NavItemLinkProps = {
   item: NavLink;
   isCurrent: boolean;
   variant: "desktop" | "mobile";
 };
 
-function NavItemLink({ item, isCurrent, variant }: NavLinkProps) {
+function NavItemLink({ item, isCurrent, variant }: NavItemLinkProps) {
   if (variant === "mobile") {
     return (
       <Link

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -9,16 +9,11 @@ import { CtaButton } from "~/components/cta-button";
 import { ThemeToggle } from "~/components/theme-toggle";
 import { Wordmark } from "~/components/wordmark";
 import { cn } from "~/lib/cn";
+import type { ResolvedCta } from "~/lib/page-href";
 
 export type NavLink = {
   title: string;
   href: string;
-};
-
-export type NavCta = {
-  label: string;
-  href: string;
-  download: boolean;
 };
 
 function isActive({ pathname, href }: { pathname: string; href: string }) {
@@ -73,7 +68,7 @@ function NavItemLink({ item, isCurrent, variant }: NavLinkProps) {
 
 type SiteHeaderProps = {
   items: ReadonlyArray<NavLink>;
-  cta: NavCta | null;
+  cta: ResolvedCta | null;
 };
 
 export function SiteHeader({ items, cta }: SiteHeaderProps) {

--- a/src/fields/blocks.ts
+++ b/src/fields/blocks.ts
@@ -21,11 +21,6 @@ const BLOCKS: ReadonlyArray<Block> = [
   StoryBlock,
 ] as const;
 
-/**
- * The block-based page layout field — the full set of blocks a Page is
- * composed from. `overrides` tune the field (name, admin, …); the block list
- * is replaced wholesale if overridden (see `deepMergeWithSourceArrays`).
- */
 export function blocksField(overrides: Partial<BlocksField> = {}): BlocksField {
   return deepMergeWithSourceArrays<BlocksField>(
     {

--- a/src/fields/link.ts
+++ b/src/fields/link.ts
@@ -14,17 +14,6 @@ const validateDownloadFile: UploadFieldSingleValidation = (
     ? "Add a file to download."
     : true;
 
-/**
- * The subfields of a link: a label plus a target. A link points either at a
- * Page (so it follows slug changes rather than rotting) or at a file in the
- * Media collection rendered as a download (e.g. a resume). External URLs are
- * still out of scope until a real need appears (issue #23).
- *
- * Returned fresh per call rather than shared from a constant: because
- * `deepMergeWithSourceArrays` aliases array values by reference (it does not
- * clone them), a shared constant would leave every link field in the schema
- * pointing at the same mutable field objects, which Payload sanitizes in place.
- */
 function linkFields(): Array<Field> {
   return [
     {
@@ -64,11 +53,6 @@ function linkFields(): Array<Field> {
   ];
 }
 
-/**
- * A single link as a named group (a Page or a file download). Pass `overrides`
- * to rename it, mark it required, or add admin config; nested arrays in the
- * override replace the defaults (see `deepMergeWithSourceArrays`).
- */
 export function linkField(overrides: Partial<GroupField> = {}): GroupField {
   return deepMergeWithSourceArrays<GroupField>(
     {
@@ -80,10 +64,6 @@ export function linkField(overrides: Partial<GroupField> = {}): GroupField {
   );
 }
 
-/**
- * A repeatable list of links (zero or more), e.g. the calls-to-action of a
- * lockup. `overrides` tune the array (name, minRows, admin, …).
- */
 export function linksField(overrides: Partial<ArrayField> = {}): ArrayField {
   return deepMergeWithSourceArrays<ArrayField>(
     {

--- a/src/fields/lockup.ts
+++ b/src/fields/lockup.ts
@@ -1,12 +1,6 @@
 import { deepMergeWithSourceArrays, type GroupField } from "payload";
 import { linksField } from "./link";
 
-/**
- * A content lockup: the common "eyebrow / heading / subheading / body / CTAs"
- * cluster that headers, heroes, and CTA bands are all built from. Only the
- * heading is required; everything else is optional so one shape serves every
- * block. `overrides` merge over the defaults (nested arrays replace).
- */
 export function lockupField(overrides: Partial<GroupField> = {}): GroupField {
   return deepMergeWithSourceArrays<GroupField>(
     {

--- a/src/fields/nav-items.ts
+++ b/src/fields/nav-items.ts
@@ -1,0 +1,24 @@
+import { type ArrayField, deepMergeWithSourceArrays } from "payload";
+
+export function navItemsField(overrides: Partial<ArrayField> = {}): ArrayField {
+  return deepMergeWithSourceArrays<ArrayField>(
+    {
+      fields: [
+        {
+          name: "label",
+          required: true,
+          type: "text",
+        },
+        {
+          name: "page",
+          relationTo: "pages",
+          required: true,
+          type: "relationship",
+        },
+      ],
+      name: "items",
+      type: "array",
+    },
+    overrides
+  );
+}

--- a/src/fields/titled-items.ts
+++ b/src/fields/titled-items.ts
@@ -10,11 +10,6 @@ type TitledItemsOptions = {
   overrides?: Partial<ArrayField>;
 };
 
-/**
- * A repeatable list of title + description items — the shape behind value
- * props, values, how-I-work, capabilities, and approach sections. `overrides`
- * merge over the defaults (nested arrays replace).
- */
 export function titledItems({
   defaultValue = [],
   overrides = {},

--- a/src/globals/footer.ts
+++ b/src/globals/footer.ts
@@ -1,6 +1,7 @@
 import type { GlobalConfig } from "payload";
 import { anyone } from "~/access/anyone";
 import { authenticated } from "~/access/authenticated";
+import { navItemsField } from "~/fields/nav-items";
 import { revalidateChrome } from "./hooks/revalidate-layout";
 
 export const Footer: GlobalConfig = {
@@ -12,23 +13,7 @@ export const Footer: GlobalConfig = {
     group: "Site chrome",
   },
   fields: [
-    {
-      fields: [
-        {
-          name: "label",
-          required: true,
-          type: "text",
-        },
-        {
-          name: "page",
-          relationTo: "pages",
-          required: true,
-          type: "relationship",
-        },
-      ],
-      name: "items",
-      type: "array",
-    },
+    navItemsField(),
     {
       fields: [
         {

--- a/src/globals/navigation.ts
+++ b/src/globals/navigation.ts
@@ -2,6 +2,7 @@ import type { GlobalConfig } from "payload";
 import { anyone } from "~/access/anyone";
 import { authenticated } from "~/access/authenticated";
 import { linkField } from "~/fields/link";
+import { navItemsField } from "~/fields/nav-items";
 import { revalidateChrome } from "./hooks/revalidate-layout";
 
 export const Navigation: GlobalConfig = {
@@ -13,24 +14,7 @@ export const Navigation: GlobalConfig = {
     group: "Site chrome",
   },
   fields: [
-    {
-      fields: [
-        {
-          name: "label",
-          required: true,
-          type: "text",
-        },
-        {
-          name: "page",
-          relationTo: "pages",
-          required: true,
-          type: "relationship",
-        },
-      ],
-      minRows: 1,
-      name: "items",
-      type: "array",
-    },
+    navItemsField({ minRows: 1 }),
     linkField({ label: "Call to action", name: "cta" }),
   ],
   hooks: {

--- a/src/lib/page-href.ts
+++ b/src/lib/page-href.ts
@@ -10,11 +10,6 @@ export function pageHref(page: PageRef | null | undefined): string {
   return `/${slug}`;
 }
 
-/**
- * Resolves a Payload page relationship — which may be an unpopulated id
- * string, a populated page document, or null — to an href, or null when it
- * can't be resolved (e.g. depth too shallow to populate the slug).
- */
 export function pageRelationshipHref(
   page: string | PageRef | null | undefined
 ): string | null {
@@ -36,27 +31,14 @@ export type ResolvedLink = {
   download: boolean;
 };
 
-/**
- * A resolved call-to-action: a label plus its resolved link target.
- */
 export type ResolvedCta = ResolvedLink & {
   label: string;
 };
 
-/**
- * Vercel Blob serves `${url}?download=1` with `Content-Disposition: attachment`,
- * forcing a real download even cross-origin, where the anchor `download`
- * attribute alone is ignored by browsers.
- */
 function toDownloadHref(url: string): string {
   return url.includes("?") ? `${url}&download=1` : `${url}?download=1`;
 }
 
-/**
- * Resolves a link field (a Page or a file download) to an href plus whether it
- * should be offered as a download, or null when the target can't be resolved
- * (missing page/file, or a relationship too shallow to populate).
- */
 export function resolveLink(
   link: LinkValue | null | undefined
 ): ResolvedLink | null {
@@ -73,10 +55,6 @@ type CtaValue = LinkValue & {
   label?: string | null;
 };
 
-/**
- * Resolves a CTA field — a link plus its label — to a rendered CTA, or null
- * when the link can't be resolved or the label is missing.
- */
 export function resolveCta(
   cta: CtaValue | null | undefined
 ): ResolvedCta | null {

--- a/src/lib/page-href.ts
+++ b/src/lib/page-href.ts
@@ -68,3 +68,21 @@ export function resolveLink(
   const href = pageRelationshipHref(link?.page);
   return href ? { download: false, href } : null;
 }
+
+type CtaValue = LinkValue & {
+  label?: string | null;
+};
+
+/**
+ * Resolves a CTA field — a link plus its label — to a rendered CTA, or null
+ * when the link can't be resolved or the label is missing.
+ */
+export function resolveCta(
+  cta: CtaValue | null | undefined
+): ResolvedCta | null {
+  const link = resolveLink(cta);
+  if (!(cta?.label && link)) {
+    return null;
+  }
+  return { ...link, label: cta.label };
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -41,11 +41,6 @@ export default buildConfig({
     }),
   ],
   secret: process.env.PAYLOAD_SECRET ?? "",
-  // sharp 0.34's overloaded signature is structurally incompatible with
-  // Payload's single-signature SharpDependency type depending on which
-  // overload TS resolves, which varies by environment (see #22) — a
-  // deterministic double cast beats a @ts-expect-error that flip-flops
-  // between "needed" and "unused".
   sharp: sharp as unknown as SharpDependency,
   typescript: {
     outputFile: path.resolve(dirname, "payload-types.ts"),


### PR DESCRIPTION
Follow-up refactors surfaced by the code review on #34, plus an owner-directed comment sweep.

## Commits

- **refactor(cta): consolidate CTA resolution into one helper and type** — `resolveCta` helper alongside `resolveLink`; drops `NavCta` in favor of the structurally identical `ResolvedCta`. Closes #35.
- **refactor(fields): extract navItemsField factory** — Navigation and Footer share one `navItemsField(overrides)` builder; Navigation passes `minRows: 1`. Closes #36.
- **refactor(header): rename NavLinkProps to NavItemLinkProps** — props type tracks its `NavItemLink` component. Closes #37.
- **style: strip TSDoc and explanatory comments from src** — owner directive (single-maintainer repo); functional directives (`biome-ignore`) and Payload-generated files left intact.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` (ultracite) — clean
- Code review (Standards + Spec axes) on #35 and #36 came back clean; #37 is a pure rename.
- No behavior change; no automated tests (repo policy).

Closes #35, closes #36, closes #37.